### PR TITLE
Add hpcc template features

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@
 #  dc: Data Carpentry
 #  lc: Library Carpentry
 #  cp: Carpentries (to use for instructor training for instance)
+#  ucl-hpcc: UCL-RC's Introduction to HPC Incubator lesson
 #  incubator: for workshops teaching a lesson in The Carpentries Incubator
 # Note that for regular workshops, you should use:
 #  https://github.com/carpentries/workshop-template

--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,13 @@ title: "Workshop Title"
 #------------------------------------------------------------
 
 #------------------------------------------------------------
+# UCL HPCC Course settings
+#------------------------------------------------------------
+arc_website: "https://www.ucl.ac.uk/advanced-research-computing/"
+arc_education_website: "https://www.ucl.ac.uk/advanced-research-computing/education"
+hpcc_lesson_site: "http://github-pages.arc.ucl.ac.uk/hpc-intro/"
+
+#------------------------------------------------------------
 # Generic settings (should not need to change).
 #------------------------------------------------------------
 

--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,9 @@ title: "Workshop Title"
 arc_website: "https://www.ucl.ac.uk/advanced-research-computing/"
 arc_education_website: "https://www.ucl.ac.uk/advanced-research-computing/education"
 hpcc_lesson_site: "http://github-pages.arc.ucl.ac.uk/hpc-intro/"
+myriad_apply_form: "https://www.rc.ucl.ac.uk/docs/Account_Services/#apply-for-an-account"
+myriad_docs_descr: "https://www.rc.ucl.ac.uk/docs/Clusters/Myriad/"
+rc_services_docs: "https://www.rc.ucl.ac.uk/docs/"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,6 +32,10 @@
       <a href="{{ site.carpentries_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
+      {% elsif site.carpentry == "ucl-hpcc" %}
+      <a href="{{ site.incubator_lesson_site }}" class="pull-left">
+        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}"
+          alt="The Carpentries Incubator logo" />
       {% elsif site.carpentry == "incubator" %}
       <a href="{{ site.incubator_lesson_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,11 +32,7 @@
       <a href="{{ site.carpentries_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
-      {% elsif site.carpentry == "ucl-hpcc" %}
-      <a href="{{ site.incubator_lesson_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}"
-          alt="The Carpentries Incubator logo" />
-      {% elsif site.carpentry == "incubator" %}
+      {% elsif site.carpentry == "incubator" or site.carpentry == "ucl-hpcc" %}
       <a href="{{ site.incubator_lesson_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />
       {% elsif site.carpentry == "lab" %}

--- a/_includes/ucl-hpcc/intro.html
+++ b/_includes/ucl-hpcc/intro.html
@@ -1,0 +1,18 @@
+<p>
+  <a href="{{site.swc_site}}">Software Carpentry</a>
+  aims to help researchers get their work done
+  in less time and with less pain
+  by teaching them basic research computing skills.
+  This hands-on workshop will cover basic concepts and tools,
+  including program design, version control, data management,
+  and task automation.
+  Participants will be encouraged to help one another
+  and to apply what they have learned to their own research problems.
+</p>
+<p align="center">
+  <em>
+    For more information on what we teach and why,
+    please see our paper
+    "<a href="https://doi.org/10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
+  </em>
+</p>

--- a/_includes/ucl-hpcc/intro.html
+++ b/_includes/ucl-hpcc/intro.html
@@ -1,18 +1,16 @@
 <p>
-  <a href="{{site.swc_site}}">Software Carpentry</a>
-  aims to help researchers get their work done
-  in less time and with less pain
-  by teaching them basic research computing skills.
-  This hands-on workshop will cover basic concepts and tools,
-  including program design, version control, data management,
-  and task automation.
-  Participants will be encouraged to help one another
-  and to apply what they have learned to their own research problems.
-</p>
-<p align="center">
-  <em>
-    For more information on what we teach and why,
-    please see our paper
-    "<a href="https://doi.org/10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
-  </em>
+  The <a href="{{site.arc_website}}">Centre for Advanced Research Computing (ARC)</a>
+  is UCL's research, innovation and service centre for the tools, practices and systems
+  that enable computational science and digital scholarship.
+  
+  We are an innovative centre with both professional services and academic missions:
+  <ul>
+    <li>We provide advanced, reliable and secure digital research infrastructure to
+      research groups in UCL and beyond.</li>
+    <li>We are a laboratory for research, teaching and innovation in compute, data
+      and software intensive research methods.</li>
+  </ul>
+
+  You can read more about what our <a href="{{site.arc_education_website}}" target="_blank">
+    Education team offers here</a>.
 </p>

--- a/_includes/ucl-hpcc/intro.html
+++ b/_includes/ucl-hpcc/intro.html
@@ -11,6 +11,6 @@
       and software intensive research methods.</li>
   </ul>
 
-  You can read more about what our <a href="{{site.arc_education_website}}" target="_blank">
-    Education team offers here</a>.
+  You can read more about <a href="{{site.arc_education_website}}" target="_blank"> what our
+    Education team offers</a>.
 </p>

--- a/_includes/ucl-hpcc/myriad-registration.html
+++ b/_includes/ucl-hpcc/myriad-registration.html
@@ -1,0 +1,43 @@
+<div id="setup-myriad">
+    <h3>Registering for an Account on Myriad</h3>
+    <p>
+        <a href="{{site.myriad_docs_descr}}" target="_blank">Myriad</a> is one of UCL's High Performance
+        Computer (HPC) clusters, and is designed for high I/O, high throughput jobs that will run within
+        a single node, rather than multi-node parallel jobs.
+
+        In this workshop, we will be working on Myriad and exploring how to interact with the filesystem,
+        submit jobs to the scheduler, and effectively request resources for your jobs.
+        But to use Myriad, you will need an account.
+    </p>
+
+    <div>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a data-has-acccount="no" href="#myriad-no-account" aria-controls="No Account"
+                    role="tab" data-toggle="tab">I do not have a Myriad account</a></li>
+            <li role="presentation"><a data-has-account="yes" href="#myriad-has-account" aria-controls="Has Account" role="tab"
+                    data-toggle="tab">I already have a Myriad account</a></li>
+        </ul>
+
+        <div class="tab-content">
+            <article role="tabpanel" class="tab-pane active" id="myriad-no-account">
+                <p>
+                    You can apply for an account on Myriad by <a href="{{site.myriad_apply_form}}" target="_blank">completing the application form.</a>
+                    <ul>
+                        <li>You will need to use your UCL user ID when you register.</li>
+                        <li>Under the "Project Name" and "Work Description" fields, state that you are requesting an account for this course.</li>
+                    </ul>
+                </p>
+                <p>
+                    You should sign up for an account no later than 2 days before the workshop.
+                    Otherwise, there will not be time to activate your account before the workshop starts.
+                </p>
+            </article>
+            <article role="tabpanel" class="tab-pane" id="myriad-has-account">
+                <p>
+                    If you already have a Myriad account, you can use that for this course.
+                    You do not need to do anything further, but you will need your login details to hand during the workshop.
+                </p>
+            </article>
+        </div>
+    </div>
+</div>

--- a/_includes/ucl-hpcc/schedule.html
+++ b/_includes/ucl-hpcc/schedule.html
@@ -1,0 +1,40 @@
+<div class="row">
+  <div class="col-md-6">
+    <h3>Day 1</h3>
+    <table class="table table-striped">
+      <tr> <td>Before</td> <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank" rel="noopener noreferrer">Pre-workshop survey</a> </td> </tr>
+      <tr> <td>09:00</td>  <td>Automating Tasks with the Unix Shell</td> </tr>
+      <tr> <td>10:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>11:00</td>  <td>Automating Tasks with the Unix Shell (Continued)</td> </tr>
+      <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
+      {% if site.flavor == "r" %}
+      <tr> <td>13:00</td>  <td>Building Programs with R</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Building Programs with R (Continued)</td> </tr>
+      {% elsif site.flavor == "python" %}
+      <tr> <td>13:00</td>  <td>Building Programs with Python</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Building Programs with Python (Continued)</td> </tr>
+      {% else %}
+      {% include warning-flavor.html %}
+      {% endif %}
+      <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>16:30</td>  <td>END</td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Day 2</h3>
+    <table class="table table-striped">
+      <tr> <td>09:00</td>  <td>Version Control with Git</td> </tr>
+      <tr> <td>10:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>11:00</td>  <td>Version Control with Git (Continued)</td> </tr>
+      <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
+      <tr> <td>13:00</td>  <td>Managing Data with SQL</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Managing Data with SQL (Continued)</td> </tr>
+      <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>16:30</td>  <td><a href="{{ site.post_survey }}{{ site.github.project_title }}" target="_blank" rel="noopener noreferrer">Post-workshop Survey</a></td> </tr>
+      <tr> <td>16:40</td>  <td>END</td> </tr>
+    </table>
+  </div>
+</div>

--- a/_includes/ucl-hpcc/setup.html
+++ b/_includes/ucl-hpcc/setup.html
@@ -1,29 +1,3 @@
-{% assign curricula = "swc-gapminder|swc-inflammation"  | split: "|" %}
-{% unless curricula contains site.curriculum %}
-{% include warning-curriculum.html %}
-{% endunless %}
-
 {% include install_instructions/shell.html %}
-{% include install_instructions/git.html %}
-{% include install_instructions/github.html %}
-{% include install_instructions/editor.html %}
 
-{% if site.flavor == "r" %}
-{% include install_instructions/r.html %}
-{% elsif site.flavor == "python" %}
-{% include install_instructions/python.html %}
-{% elsif site.flavor == "FIXME" %}
-{% include install_instructions/r.html %}
-{% include install_instructions/python.html %}
-{% else %}
-{% include warning-flavor.html %}
-{% endif %}
-
-{% comment %}
-The following setup instructions are commented out because Carpentries workshops
-cover the these topics less frequently. Please uncomment the lines that
-correspond to the topics covered in your workshop.
-
-{% include install_instructions/sql.html %}
-{% include install_instructions/openrefine.html %}
-{% endcomment %}
+{% include ucl-hpcc/myriad-registration.html %}

--- a/_includes/ucl-hpcc/setup.html
+++ b/_includes/ucl-hpcc/setup.html
@@ -1,0 +1,29 @@
+{% assign curricula = "swc-gapminder|swc-inflammation"  | split: "|" %}
+{% unless curricula contains site.curriculum %}
+{% include warning-curriculum.html %}
+{% endunless %}
+
+{% include install_instructions/shell.html %}
+{% include install_instructions/git.html %}
+{% include install_instructions/github.html %}
+{% include install_instructions/editor.html %}
+
+{% if site.flavor == "r" %}
+{% include install_instructions/r.html %}
+{% elsif site.flavor == "python" %}
+{% include install_instructions/python.html %}
+{% elsif site.flavor == "FIXME" %}
+{% include install_instructions/r.html %}
+{% include install_instructions/python.html %}
+{% else %}
+{% include warning-flavor.html %}
+{% endif %}
+
+{% comment %}
+The following setup instructions are commented out because Carpentries workshops
+cover the these topics less frequently. Please uncomment the lines that
+correspond to the topics covered in your workshop.
+
+{% include install_instructions/sql.html %}
+{% include install_instructions/openrefine.html %}
+{% endcomment %}

--- a/_includes/ucl-hpcc/surveys.html
+++ b/_includes/ucl-hpcc/surveys.html
@@ -1,1 +1,6 @@
-<p>UCL-specific survey links will need to go here.</p>
+<p>
+    There are currently no surveys available for this workshop.
+    <!-- We might want to create our own Feedback forms, EG through MS bookings.
+     We can then link to these from this site.
+    -->
+</p>

--- a/_includes/ucl-hpcc/surveys.html
+++ b/_includes/ucl-hpcc/surveys.html
@@ -1,0 +1,1 @@
+<p>UCL-specific survey links will need to go here.</p>

--- a/_includes/ucl-hpcc/who.html
+++ b/_includes/ucl-hpcc/who.html
@@ -1,0 +1,8 @@
+<p id="who">
+  <strong>Who:</strong>
+  The course is aimed at graduate students and other researchers.
+  <strong>
+    You don't need to have any previous knowledge of the tools
+    that will be presented at the workshop.
+  </strong>
+</p>

--- a/_includes/ucl-hpcc/who.html
+++ b/_includes/ucl-hpcc/who.html
@@ -1,8 +1,8 @@
 <p id="who">
   <strong>Who:</strong>
-  The course is aimed at graduate students and other researchers.
+  The course is aimed at graduate students and other researchers who would like to use UCL's HPC clusters to run high-throughput analysis pipelines.
   <strong>
-    You don't need to have any previous knowledge of the tools
-    that will be presented at the workshop.
+  You will need to be comfortable using the UNIX command line to interact with a machine, before you start this course.
   </strong>
+  The <a href="https://swcarpentry.github.io/shell-novice/" target="_blank">Introduction to the UNIX shell</a> Carpentries lesson is a suitable pre-requisite, and ARC typically run an instance of this course every term.
 </p>

--- a/index.md
+++ b/index.md
@@ -145,6 +145,8 @@ Sign up to receive future editions and read our full archive: <a href="https://c
 {% include dc/intro.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/intro.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/intro.html %}
 {% endif %}
 
 {% if site.pilot %}
@@ -163,6 +165,8 @@ workshop is only open to people from a particular institution.
 {% include dc/who.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/who.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/who.html %}
 {% endif %}
 
 {% comment %}
@@ -384,6 +388,8 @@ Please comment out the `incubator_pre_survey` and `incubator_post_survey` fields
 in `_config.yml` or, if this workshop is teaching a lesson in the Incubator,
 change the value of `carpentry` to `incubator`.
 </div>
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/surveys.html %}
 {% else %}
 <p><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
@@ -422,6 +428,8 @@ of code below the Schedule `<h2>` header below with
 {% include dc/schedule.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/schedule.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/schedule.html %}
 {% elsif site.carpentry == "incubator" %}
 This workshop is teaching a lesson in 
 <a href="https://carpentries-incubator.org/">The Carpentries Incubator</a>. Please check <a href="{{site.incubator_lesson_site}}">the lesson homepage</a> for a list of lesson sections and estimated timings.
@@ -494,10 +502,12 @@ during the workshop.
 
 {% if site.carpentry == "swc" %}
 {% include swc/setup.html %}
-{% elsif site.carpentry == "dc" %}
+{% elsif site.carpentry == "dc" %}f
 {% include dc/setup.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/setup.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/setup.html %}
 {% elsif site.carpentry == "incubator" %}
 Please check the "Setup" page of
 <a href="{{site.incubator_lesson_site}}">the lesson homepage</a> for instructions to follow

--- a/index.md
+++ b/index.md
@@ -502,7 +502,7 @@ during the workshop.
 
 {% if site.carpentry == "swc" %}
 {% include swc/setup.html %}
-{% elsif site.carpentry == "dc" %}f
+{% elsif site.carpentry == "dc" %}
 {% include dc/setup.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/setup.html %}


### PR DESCRIPTION
Allows us to set

```yaml
carpentry: "ucl-hpcc"
```

in `_config.yml`. This should then fetch the content in the new `_includes/ucl-hpcc` folder and insert it into the relevant places like the standard Carpentries courses do.

This should make creating future HPCC workshop websites faster.
