### PR TITLE
Allows selection of miniforge/anaconda installation instructions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,8 @@ curriculum: "FIXME"
 # instructions updated accordingly (valid values are 'r' or 'python').
 # Note: this is only for Data Carpentry and SWC at this time.
 flavor: "FIXME"
-
+# which python installation step is preferred anaconda|miniforge
+python_install: "FIXME"
 # If the workshop will be a lesson pilot (for a new official lesson or
 # a lesson in The Carpentries Incubator), set pilot to "true"
 pilot: false

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -13,7 +13,11 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     research computing, and great for general-purpose programming as
     well.  Installing all of its research packages individually can be
     a bit difficult, so we recommend
+    {% if site.python_install == "miniforge" %}
     <a href="https://conda-forge.org/download/">Conda-forge</a>,
+    {% else %}
+    <a href="https://www.anaconda.com/download/success">Anaconda</a>,
+    {% endif %}
     an all-in-one installer.
   </p>
 
@@ -31,6 +35,9 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   <p>
     We will teach Python using the <a href="https://jupyter.org/">Jupyter Notebook</a>,
     a programming environment that runs in a web browser (Jupyter Notebook will be installed by Miniforge). For this to work you will need a reasonably
+    {% else %}
+    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Anaconda). For this to work you will need a reasonably
+    {% endif %}
     up-to-date browser. The current versions of the Chrome, Safari and
     Firefox browsers are all
     <a href="https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility">supported</a>
@@ -48,6 +55,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     <div class="tab-content">
       <article role="tabpanel" class="tab-pane active" id="python-windows">
         <ol>
+          {% if site.python_install == "miniforge" %}
           <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
           <li>Download the Miniforge for Windows installer</li>
 	  <li>Double click on the downloaded file (Something like, <code>Minforge3-Windows-x86_64.exe</code>)</li>
@@ -67,10 +75,16 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
 	  </li>
 	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f .\Downloads\swc_environment.yml</code></li>
           <li>Close the terminal window.</li>
+          {% else %}
+          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
+          <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
+          <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
+	  {% endif %}
         </ol>
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>
+          {% if site.python_install == "miniforge" %}
           <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
           <li>Download the appropriate Miniforge installer for macOS<br>
 	    (The following steps requires using the shell. If you aren't
@@ -105,27 +119,50 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
           <li>
             Close the terminal window.
           </li>
+          {% else %}
+          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
+          <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
+          <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
+	  {% endif %}
         </ol>
+       {% if site.python_install == "miniforge" %}
+       {% else %}
+        <h4>Video Tutorial</h4>
+        <div class="yt-wrapper2">
+        <div class="yt-wrapper">
+        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
+        </div>
+        </div>
+       {% endif %}
+
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
         <ol>
+          {% if site.python_install == "miniforge" %}
           <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
           <li>Download the appropriate Miniforge installer for Linux<br>
 	    (The following steps requires using the shell. If you aren't
             comfortable doing the installation yourself
             stop here and request help at the workshop.)
 	  </li>
+          {% else %}
+          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
           <li>Download the Anaconda Installer with Python 3 for Linux.<br>
             (The installation requires using the shell. If you aren't
             comfortable doing the installation yourself
             stop here and request help at the workshop.)
           </li>
+          {% endif %}
           <li>
             Open a terminal window and navigate to the directory where
             the executable is downloaded (e.g., `cd ~/Downloads`).
           </li>
           <li>
+            {% if site.python_install == "miniforge" %}
+            Type <pre>bash Miniforge3-</pre> and then press
+	    {% else %}
             Type <pre>bash Anaconda3-</pre> and then press
+	    {% endif %}
             <kbd>Tab</kbd> to autocomplete the full file name. The name of
             file you just downloaded should appear.
           </li>
@@ -143,8 +180,10 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             to prepend Anaconda to your <code>PATH</code>
             (this makes the Anaconda distribution the default Python).
           </li>
+          {% if site.python_install == "miniforge" %}
 	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
 	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
+	  {% endif %}
           <li>
             Close the terminal window.
           </li>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -111,8 +111,8 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             for the files.
             Type <code>yes</code> and press
             <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to prepend Anaconda to your <code>PATH</code>
-            (this makes the Anaconda distribution the default Python).
+            to prepend Miniforge to your <code>PATH</code>
+            (this makes the Miniforge distribution the default Python).
           </li>
 	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
 	  <li>On the terminal run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
@@ -177,8 +177,13 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             for the files.
             Type <code>yes</code> and press
             <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            {% if site.python_install == "miniforge" %}
+            to prepend Miniforge to your <code>PATH</code>
+            (this makes the Miniforge distribution the default Python).
+	    {% else %}
             to prepend Anaconda to your <code>PATH</code>
             (this makes the Anaconda distribution the default Python).
+            {% endif %}
           </li>
           {% if site.python_install == "miniforge" %}
 	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>


### PR DESCRIPTION
A way to keep both instructions available to use them depending of the workshop.