### PR TITLE
Add page toggle for flagging in-person workshops

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ layout: workshop      # DON'T CHANGE THIS.
 # https://carpentries.github.io/workshop-template/customization/index.html
 venue: "FIXME"        # brief name of the institution that hosts the workshop without address (e.g., "Euphoric State University")
 address: "FIXME"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria"), videoconferencing URL, or 'online'
+flag_in_person: ""    # Provide "true" to include text in the general information, stressing the workshop is in-person attendance only.
 country: "FIXME"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) for the institution that hosts the workshop
 language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the workshop
 latitude: "45"        # decimal latitude of workshop venue (use https://www.latlong.net/)
@@ -155,6 +156,12 @@ Sign up to receive future editions and read our full archive: <a href="https://c
 {% if site.pilot %}
 This is a pilot workshop, testing out a lesson that is still under development. The lesson authors would appreciate any feedback you can give them about the lesson content and suggestions for how it could be further improved.
 {% endif %}
+
+{% if page.flag_in_person == "true" %}
+<div class="alert alert-warning">
+<p>Please note, this workshop will be taking place <b>in-person only.</b></p>
+</div>
+{%endif %}
 
 {% comment %}
 AUDIENCE


### PR DESCRIPTION
Adds a short box with text explaining that the workshop will be running in-person only, when the `page.flag_in_person` metadata option is set to `"true"`.

![Screenshot from 2025-05-12 09-54-34](https://github.com/user-attachments/assets/1263bf53-d374-46c7-b03f-af2d5f6091dc)

This should hopefully cut down on the number of emails we get 1-2 days before the workshop saying "I didn't realise it was in person".